### PR TITLE
Fix HCI FIFO RP2040 issue

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -7,6 +7,13 @@
 cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
+# Apply Zephyr patches before build
+file(GLOB_RECURSE files RELATIVE ${CMAKE_SOURCE_DIR} "patches/*.diff")
+foreach(file ${files})
+    execute_process(COMMAND 
+                    patch -p1 -d $ENV{ZEPHYR_BASE} -i ${CMAKE_CURRENT_SOURCE_DIR}/${file} -r - --no-backup-if-mismatch)
+endforeach()
+
 project(app LANGUAGES C)
 
 FILE(GLOB app_sources src/*.c)

--- a/app/patches/apply.txt
+++ b/app/patches/apply.txt
@@ -1,0 +1,1 @@
+git apply 85539.diff

--- a/app/patches/fix-fifo-85539.diff
+++ b/app/patches/fix-fifo-85539.diff
@@ -1,0 +1,34 @@
+diff --git a/drivers/serial/uart_pl011.c b/drivers/serial/uart_pl011.c
+index cbaa507e9a7c..1a43a26b0d72 100644
+--- a/drivers/serial/uart_pl011.c
++++ b/drivers/serial/uart_pl011.c
+@@ -343,6 +343,8 @@ static void pl011_irq_tx_enable(const struct device *dev)
+ 
+ 	get_uart(dev)->imsc |= PL011_IMSC_TXIM;
+ 	if (data->sw_call_txdrdy) {
++		data->sw_call_txdrdy = false;
++
+ 		/* Verify if the callback has been registered */
+ 		if (data->irq_cb) {
+ 			/*
+@@ -357,14 +359,18 @@ static void pl011_irq_tx_enable(const struct device *dev)
+ 			 * [1]: PrimeCell UART (PL011) Technical Reference Manual
+ 			 *      functional-overview/interrupts
+ 			 */
+-			data->irq_cb(dev, data->irq_cb_data);
++			while (get_uart(dev)->imsc & PL011_IMSC_TXIM) {
++				data->irq_cb(dev, data->irq_cb_data);
++			}
+ 		}
+-		data->sw_call_txdrdy = false;
+ 	}
+ }
+ 
+ static void pl011_irq_tx_disable(const struct device *dev)
+ {
++	struct pl011_data *data = dev->data;
++
++	data->sw_call_txdrdy = true;
+ 	get_uart(dev)->imsc &= ~PL011_IMSC_TXIM;
+ }
+ 

--- a/boards/protocentral/healthypi5/healthypi5.dts
+++ b/boards/protocentral/healthypi5/healthypi5.dts
@@ -140,7 +140,7 @@
 };
 
 &uart1 {
-	current-speed = <230400>;
+	current-speed = <921600>;
 	status = "okay";
 	pinctrl-0 = <&uart1_default>;
 	pinctrl-names = "default";

--- a/west.yml
+++ b/west.yml
@@ -12,8 +12,8 @@ manifest:
       url-base: https://github.com/Protocentral
 
   projects:
-    - name: zephyr-healthypi5
-      remote: protocentral
+    - name: zephyr
+      remote: zephyrproject-rtos
       revision: v3.7-branch
       import: 
         # By using name-allowlist we can clone only the modules that are

--- a/west.yml
+++ b/west.yml
@@ -7,7 +7,7 @@ manifest:
 
   remotes:
     - name: zephyrproject-rtos
-      url-base: https://github.com/Protocentral/zephyr-healthypi5
+      url-base: https://github.com/zephyrproject-rtos
     - name: protocentral
       url-base: https://github.com/Protocentral
 


### PR DESCRIPTION
This pull request includes several changes to improve the build process, apply patches, and update configurations for the HealthyPi5 project. The most important changes include applying Zephyr patches during the build, updating UART configurations, and modifying the repository URLs in the `west.yml` manifest.

### Build Process Improvements:
* [`app/CMakeLists.txt`](diffhunk://#diff-fd99ceeacdfe207bd1168e1c30c94ed9f316895e74154c83258807c703288b3fR10-R16): Added a process to apply Zephyr patches before the build by iterating over all `.diff` files in the `patches` directory and applying them using the `patch` command.

### Patch Application:
* [`app/patches/apply.txt`](diffhunk://#diff-fa1edb12d7ec5bb87573119961da27a927ed2fe25125471b7c8ce3548af0f52bR1): Added a command to apply the `85539.diff` patch.
* [`app/patches/fix-fifo-85539.diff`](diffhunk://#diff-f459d5f65a115447440e2e6a8ab64e8a285f91279e6c7f3021d1a1b0cc1762a8R1-R34): Added a patch to fix issues in `drivers/serial/uart_pl011.c` by modifying the interrupt handling logic.

### Configuration Updates:
* [`boards/protocentral/healthypi5/healthypi5.dts`](diffhunk://#diff-7cdc7f4389f034c5a46920694c69a60aa9e93faa126fee651021b08e18696743L143-R143): Updated the UART1 configuration to increase the current speed from `230400` to `921600`.
* [`west.yml`](diffhunk://#diff-d7f4082837dc3cb270fcf1abd68188216fdadee294e01611b8ca59ddea7fdbb3L10-R16): Modified the repository URLs to use the `zephyrproject-rtos` remote instead of `Protocentral` for the Zephyr project.