### PR TITLE
Migrate to Zephyr 4.1.0

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -8,11 +8,11 @@ cmake_minimum_required(VERSION 3.13.1)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 # Apply Zephyr patches before build
-file(GLOB_RECURSE files RELATIVE ${CMAKE_SOURCE_DIR} "patches/*.diff")
-foreach(file ${files})
-    execute_process(COMMAND 
-                    patch -p1 -d $ENV{ZEPHYR_BASE} -i ${CMAKE_CURRENT_SOURCE_DIR}/${file} -r - --no-backup-if-mismatch)
-endforeach()
+#file(GLOB_RECURSE files RELATIVE ${CMAKE_SOURCE_DIR} "patches/*.diff")
+#foreach(file ${files})
+#    execute_process(COMMAND 
+#                    patch -p1 -d $ENV{ZEPHYR_BASE} -i ${CMAKE_CURRENT_SOURCE_DIR}/${file} -r - --no-backup-if-mismatch)
+#endforeach()
 
 project(app LANGUAGES C)
 

--- a/app/src/display_module.c
+++ b/app/src/display_module.c
@@ -352,7 +352,7 @@ void draw_header(lv_obj_t *parent, bool showFWVersion)
     lv_style_set_bg_color(&style_scr_back, lv_color_black());
     lv_obj_add_style(parent, &style_scr_back, 0);
 
-    lv_disp_set_bg_color(NULL, lv_color_black());
+    //lv_disp_set_bg_color(NULL, lv_color_black());
 
     lv_obj_t *header_bar = lv_obj_create(parent);
     lv_obj_set_size(header_bar, 480, 30);

--- a/app/src/hw_module.c
+++ b/app/src/hw_module.c
@@ -297,7 +297,7 @@ static void gpio_keys_cb_handler(struct input_event *evt)
     }
 #endif
 }
-INPUT_CALLBACK_DEFINE(gpio_keys_dev, gpio_keys_cb_handler);
+INPUT_CALLBACK_DEFINE(gpio_keys_dev, gpio_keys_cb_handler, NULL);
 
 void hw_thread(void)
 {

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -27,7 +27,7 @@ int main(void)
 	return 0;
 }
 
-void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
+/*void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
 {
     LOG_PANIC();
 
@@ -35,4 +35,4 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
     sys_reboot(SYS_REBOOT_COLD);
 
     CODE_UNREACHABLE;
-}
+}*/

--- a/app/src/sampling_module.c
+++ b/app/src/sampling_module.c
@@ -21,11 +21,11 @@ extern const struct device *const max30205_dev;
 #define PPG_SAMPLING_INTERVAL_MS 8
 #define ECG_SAMPLING_INTERVAL_MS 50
 
-K_MSGQ_DEFINE(q_ecg_bioz_sample, sizeof(struct hpi_ecg_bioz_sensor_data_t), 256, 1);
+K_MSGQ_DEFINE(q_ecg_bioz_sample, sizeof(struct hpi_ecg_bioz_sensor_data_t), 64, 1);
 K_MSGQ_DEFINE(q_ppg_sample, sizeof(struct hpi_ppg_sensor_data_t), 64, 1);
 
-RTIO_DEFINE(max30001_read_rtio_poll_ctx, 16, 16);
-RTIO_DEFINE(afe4400_read_rtio_poll_ctx, 16, 16);
+RTIO_DEFINE(max30001_read_rtio_poll_ctx, 1, 1);
+RTIO_DEFINE(afe4400_read_rtio_poll_ctx, 1, 1);
 
 SENSOR_DT_READ_IODEV(max30001_iodev, DT_ALIAS(max30001), {SENSOR_CHAN_VOLTAGE});
 SENSOR_DT_READ_IODEV(afe4400_iodev, DT_ALIAS(afe4400), {SENSOR_CHAN_RED});
@@ -143,5 +143,5 @@ void ecg_bioz_sample_trigger_thread(void)
 
 #define ECG_SAMPLING_THREAD_PRIORITY 7
 
-K_THREAD_DEFINE(ecg_bioz_sample_trigger_thread_id, 4096, ecg_bioz_sample_trigger_thread, NULL, NULL, NULL, ECG_SAMPLING_THREAD_PRIORITY, 0, 1000);
+//K_THREAD_DEFINE(ecg_bioz_sample_trigger_thread_id, 4096, ecg_bioz_sample_trigger_thread, NULL, NULL, NULL, ECG_SAMPLING_THREAD_PRIORITY, 0, 1000);
 K_THREAD_DEFINE(ppg_sample_trigger_thread_id, 1024, ppg_sample_trigger_thread, NULL, NULL, NULL, ECG_SAMPLING_THREAD_PRIORITY, 0, 1000);

--- a/app/src/ui/screens/scr_ppg.c
+++ b/app/src/ui/screens/scr_ppg.c
@@ -43,7 +43,7 @@ void draw_scr_ppg(enum scroll_dir m_scroll_dir)
     lv_obj_set_style_bg_color(chart_ppg, lv_color_black(), LV_STATE_DEFAULT);
     lv_obj_set_style_border_width(chart_ppg, 0, LV_PART_MAIN);
 
-    lv_obj_set_style_size(chart_ppg, 0, LV_PART_INDICATOR);
+    //lv_obj_set_style_size(chart_ppg, 0, LV_PART_INDICATOR);
     lv_chart_set_point_count(chart_ppg, PPG_DISP_WINDOW_SIZE);
     lv_chart_set_range(chart_ppg, LV_CHART_AXIS_PRIMARY_Y, -200, 250);
     lv_chart_set_div_line_count(chart_ppg, 0, 0);

--- a/boards/protocentral/healthypi5/healthypi5.dts
+++ b/boards/protocentral/healthypi5/healthypi5.dts
@@ -5,7 +5,7 @@
 
 #include <freq.h>
 
-#include <rpi_pico/rp2040.dtsi>
+#include <raspberrypi/rpi_pico/rp2040.dtsi>
 #include "healthypi5-pinctrl.dtsi"
 #include <zephyr/dt-bindings/pwm/pwm.h>
 
@@ -247,7 +247,7 @@
 		spi-max-frequency = <DT_FREQ_M(4)>;
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
-			//disk-name = "sdhc0";
+			disk-name = "sdhc0";
 			status = "okay";
 
 		};

--- a/clean.sh
+++ b/clean.sh
@@ -1,1 +1,1 @@
-west build -t clean -b healthypi5_rp2040 app
+west build -t clean -b healthypi5 app

--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v3.7-branch
+      revision: v4.1.0-rc3
       import: 
         # By using name-allowlist we can clone only the modules that are
         # strictly needed by the application.

--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v4.1.0-rc3
+      revision: v4.1-branch
       import: 
         # By using name-allowlist we can clone only the modules that are
         # strictly needed by the application.


### PR DESCRIPTION
This pull request includes several changes across multiple files to improve configuration, update dependencies, and modify existing code. The most important changes include commenting out unnecessary code, updating configurations, and modifying callback definitions.

Code simplifications:
* [`app/CMakeLists.txt`](diffhunk://#diff-fd99ceeacdfe207bd1168e1c30c94ed9f316895e74154c83258807c703288b3fL11-R15): Remove application of Zephyr patches before the build.

Configuration updates:
* [`west.yml`](diffhunk://#diff-d7f4082837dc3cb270fcf1abd68188216fdadee294e01611b8ca59ddea7fdbb3L17-R17): Updated the Zephyr project revision from v3.7-branch to v4.1-branch.
* [`boards/protocentral/healthypi5/healthypi5.dts`](diffhunk://#diff-7cdc7f4389f034c5a46920694c69a60aa9e93faa126fee651021b08e18696743L8-R8): Changed the include path for `rp2040.dtsi` and added the `disk-name` property for the MMC configuration. [[1]](diffhunk://#diff-7cdc7f4389f034c5a46920694c69a60aa9e93faa126fee651021b08e18696743L8-R8) [[2]](diffhunk://#diff-7cdc7f4389f034c5a46920694c69a60aa9e93faa126fee651021b08e18696743L250-R250)

Callback and thread definitions:
* [`app/src/hw_module.c`](diffhunk://#diff-7f05f3dcca529f606d8f24fbdb5eb26d8d24c5ad12c9d49e4c44924a06d883cfL300-R300): Modified the `INPUT_CALLBACK_DEFINE` macro to include an additional `NULL` parameter.
* [`app/src/sampling_module.c`](diffhunk://#diff-6d4a8b2be7db76bf57f803f9db1b0bdd3b1296754c510280821ecc61001e69dfL24-R28): Reduced the message queue size and the RTIO context size, and commented out the thread definition for `ecg_bioz_sample_trigger_thread`. [[1]](diffhunk://#diff-6d4a8b2be7db76bf57f803f9db1b0bdd3b1296754c510280821ecc61001e69dfL24-R28) [[2]](diffhunk://#diff-6d4a8b2be7db76bf57f803f9db1b0bdd3b1296754c510280821ecc61001e69dfL146-R146)

Build script update:
* [`clean.sh`](diffhunk://#diff-ae565074a59b1eb6a8d16d9e8d3a40f89726ebf02debba40343b5d3f098ba9dcL1-R1): Updated the board name in the `west build` command from `healthypi5_rp2040` to `healthypi5`.